### PR TITLE
Add Clython-compatible benchmark variants

### DIFF
--- a/benchmarks/binary-trees/python/binarytrees_clython.py
+++ b/benchmarks/binary-trees/python/binarytrees_clython.py
@@ -1,0 +1,31 @@
+# binary-trees — Clython-compatible variant
+# Workarounds: hardcoded n=21 (no sys), print() multi-arg (no % format)
+# Remove workarounds when Clython issues #177 and sys.argv are resolved.
+MIN_DEPTH = 4
+n = 21
+
+def make_tree(depth):
+    if depth <= 0:
+        return (None, None)
+    depth -= 1
+    return (make_tree(depth), make_tree(depth))
+
+def check_tree(node):
+    left, right = node
+    if left is None:
+        return 1
+    return 1 + check_tree(left) + check_tree(right)
+
+max_depth = max(MIN_DEPTH + 2, n)
+stretch_depth = max_depth + 1
+sd_check = check_tree(make_tree(stretch_depth))
+print("stretch tree of depth", stretch_depth, "check:", sd_check)
+long_lived = make_tree(max_depth)
+for depth in range(MIN_DEPTH, max_depth + 1, 2):
+    iterations = 1 << (max_depth - depth + MIN_DEPTH)
+    check = 0
+    for _ in range(iterations):
+        check += check_tree(make_tree(depth))
+    print(iterations, "trees of depth", depth, "check:", check)
+ll_check = check_tree(long_lived)
+print("long lived tree of depth", max_depth, "check:", ll_check)

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -105,7 +105,12 @@ compile_and_run() {
             # Clython (Python interpreter in Common Lisp)
             if [ -x "$ROOT_DIR/.clython/bin/clython" ]; then
                 echo "=== $bench / clython ==="
-                if result=$(run_single "$bench" "clython" "$ROOT_DIR/.clython/bin/clython $src" "$arg" 2>/dev/null); then
+                # Prefer _clython.py variant (hardcoded values, no sys dependency)
+                clython_src=$(find "$(dirname "$src")" -name "*_clython.py" | head -1)
+                clython_target="${clython_src:-$src}"
+                # Clython-compatible scripts are self-contained (ignore arg)
+                clython_arg="${clython_src:+}"
+                if result=$(run_single "$bench" "clython" "$ROOT_DIR/.clython/bin/clython $clython_target" "${clython_arg:-$arg}" 2>/dev/null); then
                     json_line=$(echo "$result" | tail -1)
                     if [[ "$json_line" == \{* ]]; then
                         echo "$json_line" >> "$RESULTS_DIR/results.jsonl"


### PR DESCRIPTION
Adds hardcoded Clython-compatible Python scripts to work around Clython's current limitations.

**What works:**
- `binary-trees` — Clython can run this with hardcoded n=21 and `print()` multi-arg instead of `%` formatting

**What's blocked (filed upstream):**
- `fannkuch-redux` — blocked by Clython scoping bug ([#178](https://github.com/exokomodo/clython/issues/178)) and list slice assignment ([#176](https://github.com/exokomodo/clython/issues/176))
- `n-body` — needs more testing; complex dict/list mutations

**Runner change:**
The Python section of the runner now prefers `*_clython.py` variants when running under Clython. These self-contained scripts ignore the CLI arg (hardcoded values).